### PR TITLE
Use official gm releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ RUN yum update -y
 RUN yum install -y libpng-devel libjpeg-devel libtiff-devel libuuid-devel gcc
 
 ARG GM_VERSION
+ARG GM_MINOR_VERSION
 
-RUN curl https://versaweb.dl.sourceforge.net/project/graphicsmagick/graphicsmagick/${GM_VERSION}/GraphicsMagick-${GM_VERSION}.tar.xz | tar -xJ && \
+RUN curl "ftp://ftp.graphicsmagick.org/pub/GraphicsMagick/$GM_MINOR_VERSION/GraphicsMagick-$GM_VERSION.tar.xz" | tar -xJ && \
   cd GraphicsMagick-${GM_VERSION} && \
   ./configure --prefix=/opt --enable-shared=no --enable-static=yes --with-gs-font-dir=/opt/share/fonts/default/Type1 && \
   make && \

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 export GM_VERSION=1.3.31
+export GM_MINOR_VERSION=$(echo $GM_VERSION | sed -e "s/\.[0-9]*$//g")
 
-docker build --build-arg GM_VERSION -t gm-lambda-layer .
+docker build --build-arg GM_VERSION --build-arg GM_MINOR_VERSION -t gm-lambda-layer .
 docker run --rm gm-lambda-layer cat /tmp/gm-${GM_VERSION}.zip > ./layer.zip


### PR DESCRIPTION
Changing `...versaweb.dl.sourceforge.net` to `ftp://ftp.graphicsmagick.org/pub`. Using the official package will not raise questions around security. 

Let me know what you think.